### PR TITLE
Sort filenames in path utils

### DIFF
--- a/utils/Path_utils.py
+++ b/utils/Path_utils.py
@@ -11,7 +11,7 @@ def get_image_paths(dir_path, image_extensions=image_extensions):
         for x in list(scandir(str(dir_path))):
             if any([x.name.lower().endswith(ext) for ext in image_extensions]):
                 result.append(x.path)
-    return result
+    return sorted(result)
 
 def get_image_unique_filestem_paths(dir_path, verbose_print_func=None):
     result = get_image_paths(dir_path)
@@ -26,7 +26,7 @@ def get_image_unique_filestem_paths(dir_path, verbose_print_func=None):
             continue
         result_dup.add(f_stem)
 
-    return result
+    return sorted(result)
     
 def get_file_paths(dir_path):
     dir_path = Path (dir_path)
@@ -34,7 +34,7 @@ def get_file_paths(dir_path):
     result = []
     if dir_path.exists():
         return [ x.path for x in list(scandir(str(dir_path))) if x.is_file() ]
-    return result
+    return sorted(result)
     
 def get_all_dir_names (dir_path):
     dir_path = Path (dir_path)
@@ -43,7 +43,7 @@ def get_all_dir_names (dir_path):
     if dir_path.exists():
         return [ x.name for x in list(scandir(str(dir_path))) if x.is_dir() ]
         
-    return result
+    return sorted(result)
     
 def get_all_dir_names_startswith (dir_path, startswith):
     dir_path = Path (dir_path)
@@ -54,14 +54,14 @@ def get_all_dir_names_startswith (dir_path, startswith):
         for x in list(scandir(str(dir_path))):
             if x.name.lower().startswith(startswith):
                 result.append ( x.name[len(startswith):] )
-    return result
+    return sorted(result)
 
 def get_first_file_by_stem (dir_path, stem, exts=None):
     dir_path = Path (dir_path)
     stem = stem.lower()
 
     if dir_path.exists():
-        for x in list(scandir(str(dir_path))):
+        for x in sorted(list(scandir(str(dir_path)))):
             if not x.is_file():
                 continue
             xp = Path(x.path)


### PR DESCRIPTION
Linux does not guarantee filenames are returned in any specific order. This leads to exporting frames in random order, sorting them here makes the export run sequentially. Other portions of the program should remain unaffected, if not behave more consistently across platforms (E.G. get_first_file_by_stem).